### PR TITLE
#4 Prepare image buffer in another thread

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,13 @@ use std::env;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
 use std::time::{Duration, SystemTime};
 
 #[cfg(test)]
 mod tests;
 
+#[derive(Clone)]
 struct ImgBuf {
     pub buf: Vec<u32>,
     pub width: usize,
@@ -158,36 +160,55 @@ where
     }
 }
 
-fn image_buffer_from_filepath<P>(filepath: P) -> Result<ImgBuf, ImageBufferError>
-where
+fn image_buffer_from_filepath<P>(
+    tx: mpsc::Sender<Result<ImgBuf, ImageBufferError>>,
+    rx: mpsc::Receiver<P>,
+) where
     P: AsRef<Path>,
 {
-    let img = image::open(&filepath)?;
-    let rgb = match img.as_rgb8() {
-        Some(r) => r,
-        None => return Err(ImageBufferError::RgbParseError),
-    };
+    loop {
+        let filepath = rx.recv().unwrap();
 
-    let (width, height) = rgb.dimensions();
-    let mut buf: Vec<u32> = vec![0; (width * height) as usize];
+        let img = match image::open(&filepath) {
+            Ok(i) => i,
+            Err(e) => {
+                tx.send(Err(ImageBufferError::from(e))).unwrap();
+                continue;
+            }
+        };
+        let rgb = match img.as_rgb8() {
+            Some(r) => r,
+            None => {
+                tx.send(Err(ImageBufferError::RgbParseError)).unwrap();
+                continue;
+            }
+        };
 
-    let threads = num_cpus::get();
-    let rows_per_band = height / threads as u32 + 1;
-    let bands: Vec<&mut [u32]> = buf.chunks_mut((rows_per_band * width) as usize).collect();
-    bands.into_par_iter().enumerate().for_each(|(i, band)| {
-        for (j, b) in band.iter_mut().enumerate() {
-            let x = j as u32 % width;
-            let y = i as u32 * rows_per_band + j as u32 / width;
-            let pixel = rgb.get_pixel(x, y);
-            *b = 0xFF00_0000 | (pixel[0] as u32) << 16 | (pixel[1] as u32) << 8 | (pixel[2] as u32);
-        }
-    });
+        let (width, height) = rgb.dimensions();
+        let mut buf: Vec<u32> = vec![0; (width * height) as usize];
 
-    Ok(ImgBuf {
-        buf,
-        width: width as usize,
-        height: height as usize,
-    })
+        let threads = num_cpus::get();
+        let rows_per_band = height / threads as u32 + 1;
+        let bands: Vec<&mut [u32]> = buf.chunks_mut((rows_per_band * width) as usize).collect();
+        bands.into_par_iter().enumerate().for_each(|(i, band)| {
+            for (j, b) in band.iter_mut().enumerate() {
+                let x = j as u32 % width;
+                let y = i as u32 * rows_per_band + j as u32 / width;
+                let pixel = rgb.get_pixel(x, y);
+                *b = 0xFF00_0000
+                    | (pixel[0] as u32) << 16
+                    | (pixel[1] as u32) << 8
+                    | (pixel[2] as u32);
+            }
+        });
+
+        tx.send(Ok(ImgBuf {
+            buf,
+            width: width as usize,
+            height: height as usize,
+        }))
+        .unwrap()
+    }
 }
 
 fn new_window(size: WindowSize) -> Window {
@@ -235,13 +256,43 @@ fn main() {
     let mut rng = rand::thread_rng();
     img_filepaths.shuffle(&mut rng);
 
+    // use threads to prepare image buffer before it is needed
+    let (tx_to_main, rx_from_buf_func) = mpsc::channel();
+    let (tx_to_buf_func, rx_from_main) = mpsc::channel();
+    rayon::spawn(move || {
+        image_buffer_from_filepath(tx_to_main, rx_from_main);
+    });
+
     // load first image before opening window
-    // `img.filepaths.first()` never fail because empty error is inspected above
-    let mut img_buf = image_buffer_from_filepath(img_filepaths.first().unwrap()).unwrap();
+    let mut img_buf: ImgBuf;
+    let mut img_idx = 0;
+    tx_to_buf_func.send(img_filepaths[img_idx].clone()).unwrap();
+    loop {
+        let res = rx_from_buf_func.recv().unwrap();
+        match res {
+            Ok(ib) => {
+                img_buf = ib;
+                img_idx = (img_idx + 1) % img_filepaths.len();
+                tx_to_buf_func.send(img_filepaths[img_idx].clone()).unwrap();
+                break;
+            }
+            Err(_) => {
+                img_idx = (img_idx + 1) % img_filepaths.len();
+                if img_idx == 0 {
+                    panic!("Failed to read all of found images");
+                }
+                tx_to_buf_func.send(img_filepaths[img_idx].clone()).unwrap();
+            }
+        }
+    }
 
     let mut window = new_window(size);
-    let mut img_idx = 0;
     let mut interval_sec: f32 = 5.0;
+    let mut next_img_buf = ImgBuf {
+        buf: vec![0; 1],
+        width: 1,
+        height: 1,
+    };
     let mut start_time = SystemTime::now();
     while window.is_open() && !window.is_key_down(Key::Escape) {
         if window.is_key_pressed(Key::Up, KeyRepeat::No)
@@ -255,16 +306,26 @@ fn main() {
             interval_sec += 0.5;
             info!("Speed down: {}s", interval_sec);
         }
+
+        // If receiving buffer here, we have to `clone` this value again when
+        // setting time passes, in the following process. However, it's good to
+        // make full use of free time to read the next image buffer.
+        if let Ok(res) = rx_from_buf_func.try_recv() {
+            match res {
+                Ok(ib) => next_img_buf = ib,
+                Err(e) => {
+                    // try to read next image of next image
+                    info!("error: {:?}", e);
+                    img_idx = (img_idx + 1) % img_filepaths.len();
+                    tx_to_buf_func.send(img_filepaths[img_idx].clone()).unwrap();
+                }
+            }
+        };
+
         if start_time.elapsed().unwrap() >= Duration::from_secs_f32(interval_sec) {
             img_idx = (img_idx + 1) % img_filepaths.len();
-            // if error is detected, skip its image and try to read next one
-            img_buf = match image_buffer_from_filepath(&img_filepaths[img_idx]) {
-                Ok(i) => i,
-                Err(_) => {
-                    warn!("Failed to read image {}", img_filepaths[img_idx].display());
-                    continue;
-                }
-            };
+            img_buf = next_img_buf.clone();
+            tx_to_buf_func.send(img_filepaths[img_idx].clone()).unwrap();
             start_time = SystemTime::now();
         }
         match window.update_with_buffer(&img_buf.buf, img_buf.width, img_buf.height) {


### PR DESCRIPTION
This PR resolves #4.

## Results

Process time comparisons are following:
| - | MBP | Pi 3B |
|:---:|---:|---:|
| before (b57704a) [ms] | 26.82 | 201.19 |
| after (44a4695) [ms] | 3.22 | 15.31 |

For comparison condition,
- Shows 3 different images by 3 times, total 9 times
- Images are resized to fit 1920x1080 resolution
- ⚠️ Not strict condition
    - Allow the other processes to run
    - Didn't disconnect any input devices
    - But results are obvious

<details>
<summary>Diffs to print process time</summary>

To print process time, I applied the following diff to b57704a (before)
```diff
diff --git a/src/main.rs b/src/main.rs
index 9c3facd..ea87564 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,7 @@ fn main() {
             info!("Speed down: {}s", interval_sec);
         }
         if start_time.elapsed().unwrap() >= Duration::from_secs_f32(interval_sec) {
+            let t = SystemTime::now();
             img_idx = (img_idx + 1) % img_filepaths.len();
             // if error is detected, skip its image and try to read next one
             img_buf = match image_buffer_from_filepath(&img_filepaths[img_idx]) {
@@ -266,6 +267,7 @@ fn main() {
                 }
             };
             start_time = SystemTime::now();
+            info!("read time: {:?}", t.elapsed().unwrap());
         }
         match window.update_with_buffer(&img_buf.buf, img_buf.width, img_buf.height) {
             Ok(_) => {}
```

And, applied the following diff to 44a4695 (after)
```diff
diff --git a/src/main.rs b/src/main.rs
index 5fe98ad..b9f2075 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -359,12 +359,14 @@ fn main() {
         };
 
         if start_time.elapsed().unwrap() >= Duration::from_secs_f32(interval_sec) {
+            let t = SystemTime::now();
             img_idx = (img_idx + 1) % img_filepaths.len();
             img_buf = next_img_buf.clone();
             tx_to_buf_func
                 .send(ThreadMessage::Filepath(img_filepaths[img_idx].clone()))
                 .unwrap();
             start_time = SystemTime::now();
+            info!("read time: {:?}", t.elapsed().unwrap());
         }
         match window.update_with_buffer(&img_buf.buf, img_buf.width, img_buf.height) {
             Ok(_) => {}
```
</details>

## TODO to be left

I want to add the following test to confirm that thread panics if it receives invalid messages.
```rust
#[test]
#[should_panic]
fn test_img_buffer_with_wrong_enum() {
    let (tx1, rx1): (mpsc::Sender<ThreadMessage<PathBuf>>, mpsc::Receiver<ThreadMessage<PathBuf>>) = mpsc::channel();
    let (tx2, rx2): (mpsc::Sender<ThreadMessage<PathBuf>>, mpsc::Receiver<ThreadMessage<PathBuf>>) = mpsc::channel();
    rayon::spawn(move || {
        image_buffer_from_filepath(tx1, rx2);
    });

    tx2.send(ThreadMessage::ImageBuffer(Err(ImageBufferError::RgbParseError))).unwrap();
    tx2.send(ThreadMessage::Filepath(PathBuf::from(".gitignore"))).unwrap();
    let _ = rx1.recv(); // panics because another thread is dead
}
```

However. although the above test panics, the test fails even if I add `#[should_panic`.
I don't know why but its very simplified version ([Gist](https://gist.github.com/yammmt/d57ce7566c9d51a30231fc2f83c5f4d3)) also fails...
Are there any ways to test a panic in another thread? Or shouldn't I test it? 
Should I just ignore invalid messages instead of raising panic?

I'm not sure if unwrapping thread communications (like `tx.recv().unwrap()`) is good...
